### PR TITLE
fix: save the release version

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,13 +72,27 @@ func main() {
 
 					}
 
+					// resolve release version
+					releaseFlag := cmd.String("release")
+					var actualRelease string
+					if releaseFlag == "latest" {
+						// Get the actual latest release version from GitHub
+						ghr, err := utils.GetGithubRelease(ownerRepo[0], ownerRepo[1], "latest")
+						if err != nil {
+							return fmt.Errorf("failed to get latest release: %s", err)
+						}
+						actualRelease = ghr.TagName
+					} else {
+						actualRelease = releaseFlag
+					}
+
 					// load config
 					kc, err := config.Load(cmd.String("config"))
 					if err != nil {
 						return fmt.Errorf("%s", err)
 					}
 
-					err = kc.AddPackage(ownerRepo[0], ownerRepo[1], cmd.String("release"))
+					err = kc.AddPackage(ownerRepo[0], ownerRepo[1], actualRelease)
 					if err != nil {
 						return fmt.Errorf("%s", err)
 					}
@@ -90,7 +104,7 @@ func main() {
 
 					// auto install
 					if cmd.Bool("install") {
-						err = install.Install(ownerRepo[0], ownerRepo[1], cmd.String("release"))
+						err = install.Install(ownerRepo[0], ownerRepo[1], actualRelease)
 						if err != nil {
 							return err
 						}

--- a/main.go
+++ b/main.go
@@ -77,11 +77,11 @@ func main() {
 					var actualRelease string
 					if releaseFlag == "latest" {
 						// Get the actual latest release version from GitHub
-						ghr, err := utils.GetGithubRelease(ownerRepo[0], ownerRepo[1], "latest")
+						latestRelease, err := utils.GetGithubRelease(ownerRepo[0], ownerRepo[1], "latest")
 						if err != nil {
 							return fmt.Errorf("failed to get latest release for %s/%s: %s", ownerRepo[0], ownerRepo[1], err)
 						}
-						actualRelease = ghr.TagName
+						actualRelease = latestRelease.TagName
 					} else {
 						actualRelease = releaseFlag
 					}

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 						// Get the actual latest release version from GitHub
 						ghr, err := utils.GetGithubRelease(ownerRepo[0], ownerRepo[1], "latest")
 						if err != nil {
-							return fmt.Errorf("failed to get latest release: %s", err)
+							return fmt.Errorf("failed to get latest release for %s/%s: %s", ownerRepo[0], ownerRepo[1], err)
 						}
 						actualRelease = ghr.TagName
 					} else {


### PR DESCRIPTION
Fixes a bug where when you installed a package the config was saved with "latest" instead of the actual version